### PR TITLE
Fix multiple colspans within same row

### DIFF
--- a/lib/jekyll-spaceship/processors/table-processor.rb
+++ b/lib/jekyll-spaceship/processors/table-processor.rb
@@ -93,7 +93,8 @@ module Jekyll::Spaceship
         if not data._[namespace]
           data._[namespace] = OpenStruct.new(
             table: OpenStruct.new,
-            row: OpenStruct.new
+            row: OpenStruct.new,
+            cell: OpenStruct.new
           )
         end
         data._[namespace]
@@ -109,6 +110,7 @@ module Jekyll::Spaceship
       if scope.table.row != data.row
         scope.table.row = data.row
         scope.row.colspan = 0
+        scope.cell.colspan = 0
       end
 
       # handle colspan
@@ -121,9 +123,12 @@ module Jekyll::Spaceship
       end
       if result
         result = result[0]
-        scope.row.colspan += result.scan(/\|/).count
+        pipecount = result.scan(/\|/).count
+        scope.row.colspan += pipecount
+        scope.cell.colspan += pipecount
         cell.content = cell.content.gsub(/(\s*\|)+$/, '')
-        cell.set_attribute('colspan', scope.row.colspan + 1)
+        cell.set_attribute('colspan', scope.cell.colspan + 1)
+        scope.cell.colspan = 0
       end
     end
 

--- a/lib/jekyll-spaceship/processors/table-processor.rb
+++ b/lib/jekyll-spaceship/processors/table-processor.rb
@@ -93,8 +93,7 @@ module Jekyll::Spaceship
         if not data._[namespace]
           data._[namespace] = OpenStruct.new(
             table: OpenStruct.new,
-            row: OpenStruct.new,
-            cell: OpenStruct.new
+            row: OpenStruct.new
           )
         end
         data._[namespace]
@@ -110,7 +109,6 @@ module Jekyll::Spaceship
       if scope.table.row != data.row
         scope.table.row = data.row
         scope.row.colspan = 0
-        scope.cell.colspan = 0
       end
 
       # handle colspan
@@ -123,12 +121,10 @@ module Jekyll::Spaceship
       end
       if result
         result = result[0]
-        pipecount = result.scan(/\|/).count
-        scope.row.colspan += pipecount
-        scope.cell.colspan += pipecount
+        colspan = result.scan(/\|/).count
+        scope.row.colspan += colspan
         cell.content = cell.content.gsub(/(\s*\|)+$/, '')
-        cell.set_attribute('colspan', scope.cell.colspan + 1)
-        scope.cell.colspan = 0
+        cell.set_attribute('colspan', colspan + 1)
       end
     end
 


### PR DESCRIPTION
This fixes a problem whereby each spanning cell in | spancell1 || spancell2 || cell | spancell3 || would get progressively larger instead of all spanning their intended number of cells.

Resolved by maintaining a count per cell as well as a row-wide count for removing trailing cells.