### PR TITLE
Patch 1

### DIFF
--- a/lib/jekyll-spaceship/processors/table-processor.rb
+++ b/lib/jekyll-spaceship/processors/table-processor.rb
@@ -93,7 +93,8 @@ module Jekyll::Spaceship
         if not data._[namespace]
           data._[namespace] = OpenStruct.new(
             table: OpenStruct.new,
-            row: OpenStruct.new
+            row: OpenStruct.new,
+            cell: OpenStruct.new
           )
         end
         data._[namespace]
@@ -109,6 +110,7 @@ module Jekyll::Spaceship
       if scope.table.row != data.row
         scope.table.row = data.row
         scope.row.colspan = 0
+        scope.cell.colspan = 0
       end
 
       # handle colspan
@@ -121,9 +123,12 @@ module Jekyll::Spaceship
       end
       if result
         result = result[0]
-        scope.row.colspan += result.scan(/\|/).count
+        pipecount = result.scan(/\|/).count
+        scope.row.colspan += pipecount
+        scope.cell.colspan += pipecount
         cell.content = cell.content.gsub(/(\s*\|)+$/, '')
-        cell.set_attribute('colspan', scope.row.colspan + 1)
+        cell.set_attribute('colspan', scope.cell.colspan + 1)
+        scope.cell.colspan = 0
       end
     end
 

--- a/lib/jekyll-spaceship/processors/table-processor.rb
+++ b/lib/jekyll-spaceship/processors/table-processor.rb
@@ -93,8 +93,7 @@ module Jekyll::Spaceship
         if not data._[namespace]
           data._[namespace] = OpenStruct.new(
             table: OpenStruct.new,
-            row: OpenStruct.new,
-            cell: OpenStruct.new
+            row: OpenStruct.new
           )
         end
         data._[namespace]
@@ -110,7 +109,6 @@ module Jekyll::Spaceship
       if scope.table.row != data.row
         scope.table.row = data.row
         scope.row.colspan = 0
-        scope.cell.colspan = 0
       end
 
       # handle colspan
@@ -123,12 +121,10 @@ module Jekyll::Spaceship
       end
       if result
         result = result[0]
-        pipecount = result.scan(/\|/).count
-        scope.row.colspan += pipecount
-        scope.cell.colspan += pipecount
+        colspan = result.scan(/\|/).count
+        scope.row.colspan += colspan
         cell.content = cell.content.gsub(/(\s*\|)+$/, '')
-        cell.set_attribute('colspan', scope.cell.colspan + 1)
-        scope.cell.colspan = 0
+        cell.set_attribute('colspan', colspan + 1)
       end
     end
 


### PR DESCRIPTION
## Fix interactions between `colspan` and `rowspan`

Fixed two problems that were not addressed in previous patch:

1) Row-spanning cells '^^' would reference the wrong spancell if any previous cells in that row had width>1. This includes cells where its referenced spancell had width>1. Issue resolved by incrementing col_index using the correct width.

2) Row-spanning cells '^^' that use multiple pipe delimiters (e.g. for consistency with the referenced column-spanning cell) would cause excess cells in the row to be removed. Issue resolved by skipping the pipe-counting logic when cell is also row spanning '^^' , then removing the correct number of excess columns when handling the rowspan.
