### PR TITLE
Fix jekyllrb domain

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 </h1>
 
 <h4 align="center">
-  <a href="https://jekyllrb.org" target="_blank"><code>Jekyll</code></a> plugin for Astronauts.
+  <a href="https://jekyllrb.com" target="_blank"><code>Jekyll</code></a> plugin for Astronauts.
 </h4>
 
 <p align="center">


### PR DESCRIPTION
Should be a .com not a .org -- the .org leads to a valid website but doesn't look to be related to the project.

Did a quick grep of the repo and all other mentions of jekyllrb use the correct domain, but let me know if I've missed something.