### PR TITLE
fix: Do not use polyfill scripts from polyfill.io

### DIFF
--- a/lib/jekyll-spaceship/processors/mathjax-processor.rb
+++ b/lib/jekyll-spaceship/processors/mathjax-processor.rb
@@ -7,7 +7,6 @@ module Jekyll::Spaceship
     def self.config
       {
         'src' => [
-          'https://polyfill.io/v3/polyfill.min.js?features=es6',
           'https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js',
         ],
         'config' => {


### PR DESCRIPTION
The polyfill.io domain is under the control of a bad actor, see https://sansec.io/research/polyfill-supply-chain-attack

Removing it completely should be fine, it is no more needed by modern browsers now that IE11 is not a concern anymore.